### PR TITLE
Add test endpoints & XP injection refactor

### DIFF
--- a/AI_API_CONTRACT.md
+++ b/AI_API_CONTRACT.md
@@ -1,6 +1,6 @@
 # AI Endpoints — API Contract
 
-> **For:** AK (#3, #4) and James (#6)
+> **For:** James (#3, #4)
 > **Written by:** Josh
 >
 > These are the two endpoints I'm building that power the test page. Build your frontend against this contract.
@@ -95,7 +95,6 @@ Each result in `results[]` has a `state` field — use this to drive UI colours 
 | `"Mastered"` | Purple | Full marks + generalised beyond the prompt |
 | `"Pass"` | Green | Correct with justification |
 | `"Partial"` | Yellow | Correct answer, gaps in reasoning |
-| `"Incomplete"` | Orange | Partially correct |
 | `"Incorrect"` | Red | Wrong or blank |
 
 ---
@@ -112,7 +111,7 @@ Each result in `results[]` has a `state` field — use this to drive UI colours 
 | `bandShifted` | bool | `true` if the student levelled up |
 | `oldCum` / `newCum` | int | Cumulative XP before/after |
 
-The existing `showXPModal()` function in `app.js` already accepts this shape — reuse it.
+Build an `XPModal` React component that accepts this shape. Reference the existing `showXPModal()` in `public/app.js` for the display logic (band names, progress bars, tier labels) but reimplement it as a React component.
 
 ---
 

--- a/aiAdapters/gemini.js
+++ b/aiAdapters/gemini.js
@@ -13,6 +13,7 @@ async function generate(prompt, options = {}) {
     generationConfig: {
       ...(options.temperature !== undefined && { temperature: options.temperature }),
       ...(options.maxTokens !== undefined && { maxOutputTokens: options.maxTokens }),
+      ...(options.json && { responseMimeType: 'application/json' }),
     },
   });
 

--- a/aiAdapters/groq.js
+++ b/aiAdapters/groq.js
@@ -15,6 +15,7 @@ async function generate(prompt, options = {}) {
       messages: [{ role: 'user', content: prompt }],
       ...(options.temperature !== undefined && { temperature: options.temperature }),
       ...(options.maxTokens !== undefined && { max_tokens: options.maxTokens }),
+      ...(options.json && { response_format: { type: 'json_object' } }),
     });
     return completion.choices[0].message.content;
   } catch (err) {

--- a/prompts/test-mark.md
+++ b/prompts/test-mark.md
@@ -1,0 +1,63 @@
+You are marking a student's exam. The units being tested are listed below.
+
+{{UNITS}}
+
+The student's questions and answers will follow. For each question:
+1. Compare the student's answer to an ideal full-marks answer
+2. Assign a state and write brief feedback
+
+Then produce XP injections — one per demonstrated skill (not per question). A single question may cover multiple units.
+
+Respond with valid JSON only — no explanation, no markdown fences. Return exactly this shape:
+
+{
+  "results": [
+    {
+      "id": 1,
+      "state": "Pass",
+      "feedback": "Correct geometric intuition. Did not write convex combination formally.",
+      "exampleAnswer": "A set S ⊆ ℝⁿ is convex if for all x, y ∈ S and λ ∈ [0,1], λx + (1−λ)y ∈ S.",
+      "unitIds": [3]
+    }
+  ],
+  "xpInjections": [
+    {
+      "unitId": 3,
+      "difficultyScore": 65,
+      "performanceRatio": 0.82,
+      "notes": "Identified outer/inner functions correctly. Struggled with chain rule application."
+    }
+  ]
+}
+
+## State values (use exactly one per result):
+- "Mastered" — full marks, generalised beyond the prompt
+- "Pass" — correct with justification
+- "Partial" — correct answer, gaps in reasoning
+- "Incorrect" — wrong or blank
+
+## XP field constraints:
+
+| Field              | Type   | Range       | Notes                                                   |
+|--------------------|--------|-------------|---------------------------------------------------------|
+| unitId             | int    | 0..N-1      | Implicit depth-first ID from domain JSON                |
+| difficultyScore    | float  | 20–100      | 20 = recall, 100 = novel synthesis                      |
+| performanceRatio   | float  | 0.0–1.0     | 0.0 = blank/irrelevant, 1.0 = flawless                  |
+| notes              | string | ≤500 chars  | Handoff note: what was covered, where friction was. Does not prescribe next steps. |
+
+### Difficulty Score tiers:
+| Range  | Tier           | Description                                                        |
+|--------|----------------|--------------------------------------------------------------------|
+| 20–35  | Recall         | Single concept, 1–2 steps, no branching                            |
+| 36–55  | Procedural     | 2–4 steps, minor decision points, soft prerequisites               |
+| 56–75  | Integrative    | 2+ concepts, branching, hard prerequisites required                |
+| 76–100 | Synthesis      | Multi-unit, open-ended, meta-constraints, student defines the path |
+
+### Performance Ratio tiers:
+| Range      | Tier       | Description                                                              |
+|------------|------------|--------------------------------------------------------------------------|
+| 0.0–0.15   | Inactive   | Blank or irrelevant                                                      |
+| 0.16–0.35  | Fragmented | Partially correct, no conceptual control                                 |
+| 0.36–0.60  | Fluent     | Correct, minor gaps                                                      |
+| 0.61–0.85  | Strategic  | Correct + justified, anticipates edge cases                              |
+| 0.86–1.00  | Masterful  | Generalises, self-corrects, structural understanding                     |

--- a/prompts/test.md
+++ b/prompts/test.md
@@ -1,89 +1,15 @@
-
-
-Write a 10-question exam that tests the units I have sent you. Questions should increase in difficulty. Do not label questions with units or difficulty. Questions may multiple units all at different levels or connect them.
+Write a 10-question exam that tests the units below. Questions must increase in difficulty. Do not label questions with units or difficulty levels. Questions may combine multiple units.
 
 {{UNITS}}
 
-Respond with just the questions. Once I give my answers, mark them and compare with an example answer which would have got full marks. Then finally respond with 2 sets of json "injections". Each should be returned as copiable code blocks.
+Respond with valid JSON only — no explanation, no markdown fences. Return exactly this shape:
 
-
-## 1) XP INJECTION: 
-One json file. For every demonstrated skill. Not necessarily one injection for every question, questions may have several skills demonstrated at different performance and levels of difficulty.
-
-For example:
-```
-[
-  {
-    "unitId": 0,
-    "difficultyScore": 65,
-    "performanceRatio": 0.82,
-    "notes": "Struggled with chain rule application but correctly identified outer/inner functions."
-  },
-  {
-    "unitId": 3,
-    "difficultyScore": 40,
-    "performanceRatio": 0.95,
-    "notes": "Solid grasp of fundamental derivatives. Ready for composite functions."
-  }
-]
-```
-
-**Field Constraints**
-
-| Key                | Type     | Range         | Notes                                    |
-| ------------------ | -------- | ------------- | ---------------------------------------- |
-| `unitId`           | `int`    | `0..N-1`      | Implicit depth-first ID from domain JSON |
-| `difficultyScore`  | `float`  | `20 – 100`    | 20 = recall, 100 = novel synthesis       |
-| `performanceRatio` | `float`  | `0.0 – 1.0`   | 0.0 = blank/irrelevant, 1.0 = flawless   |
-| `notes`            | `string` | `≤ 500 chars` | Verbatim append to unit's `progressLogs` |
-
-NOTES FIELD:
-The notes field is a handoff note from the current session to the next. It notes what was covered, what wasn't covered and where the friction was.Notes how the student thought, flow, confidence and errors. Notes how they handled connections to other units. Avoids loading it with redundant information. Writes in isolation, DOES NOT note what to do in the next session.
-
-### Criteria for Difficulty Score and Performance.
-
-**Difficulty Score:** `20` (Basic) → `100` (Hardest)
-
-Difficulty is not to be mistaken with obscure and trick-laden questions. Higher order thinking is rewarded, not obscure knowlege.
-
-| Score Range  | Tier Name                       | Cognitive Load & Structure                                                                                      | Linkage & Dependencies                                                                                              | Context & Framing                                                                                                     | Consistency Anchor                                                                                                      |
-| ------------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| **20 – 35**  | **Recall & Direct Application** | **Low Load.** Single concept. 1–2 linear steps. No branching logic.                                             | **None.** Isolated unit or explicit formula application. No hidden pre-reqs.                                        | **Standard.** Familiar phrasing. Direct mapping to textbook examples.                                                 | _A student who just reviewed the unit can solve this immediately without hesitation._                                   |
-| **36 – 55**  | **Procedural Fluency**          | **Moderate Load.** Single concept + 1 supporting mechanism. 2–4 sequential steps. Minor decision points.        | **Soft Pre-reqs.** Requires recalling a related fact or minor transformation. No hard blocking dependencies.        | **Varied.** Standard concept applied to a slightly novel scenario. One mild distractor.                               | _Errors arise from skipped steps or notation slips, not conceptual misunderstanding._                                   |
-| **56 – 75**  | **Integrative Navigation**      | **High Load.** 2+ interacting concepts. 3–5 steps with branching logic. Requires prioritizing constraints.      | **Hard Pre-reqs.** Must activate a foundational unit before solving the target. Failure to link causes total block. | **Novel Framing.** Requires translating between representations (e.g., graph ↔ equation). Ambiguity in method choice. | _Correct answer depends on identifying the right dependency chain. Common failure is using right steps in wrong order._ |
-| **76 – 100** | **Synthesis & Adaptation**      | **Max Load.** Multi-unit network. Open-ended structure. Student must define the path. Meta-constraints present. | **Conjunctions.** Forces parallel processing of linked units. Requires bridging distinct broad topics.              | **Unfamiliar/Abstract.** Cross-context application. Hidden assumptions. Requires justifying method trade-offs.        | _Distinguishes mastery from fluency. Requires self-correction and handling of edge cases or conflicting constraints._   |
-
-**Performance Ratio:** `0.0` (Blank/Irrelevant) → `1.0` (Flawless)
-
-Defines reasoning fidelity and integration of ideas, not just correctness.
-
-|Ratio Range|Tier Name|Accuracy & Completeness|Reasoning Flow & Coherence|Constraint Handling|Metacognition & Transfer|Consistency Anchor|
-|---|---|---|---|---|---|---|
-|**0.0 – 0.15**|**Inactive / Misaligned**|Blank, irrelevant, or fundamentally incorrect.|Disconnected fragments. Guessing. No logical chain.|Ignored or misunderstood.|None.|_Schema not activated. Indicates a need for foundational review._|
-|**0.16 – 0.35**|**Fragmented / Mechanical**|Partially correct or coincidentally right answer.|Recognizes first step/formula but breaks down mid-process. Rigid template following.|Acknowledged but inconsistently applied. Errors in execution.|Cannot explain why a step failed. No awareness of alternatives.|_Procedural familiarity exists, but conceptual control is missing. Recoverable with a hint._|
-|**0.36 – 0.60**|**Fluent / Stable**|Correct answer.|Logical sequence. Clear cause-effect. Minor notation or efficiency gaps.|Applied correctly. Standard path followed.|Can retrace steps. Struggles if conditions change slightly.|_Reliable execution under familiar conditions. Ready for linkage stress._|
-|**0.61 – 0.85**|**Strategic / Integrated**|Correct + explicit justification.|Chooses optimal path among alternatives. Anticipates edge cases.|Actively managed. Trade-offs explained. Constraints used to guide method.|Explains _why_ the method fits. Notes limitations. Connects to related units.|_Demonstrates schema integration. Errors would only come from novel, untrained constraints._|
-|**0.86 – 1.00**|**Adaptive / Masterful**|Correct + generalizes beyond prompt.|Self-corrects mid-process. Reframes if initial approach fails. Elegant, high-order patterns.|Turns constraints into advantages. Identifies hidden assumptions.|Articulates underlying principles. Proposes extensions. Maps to broader domain.|_Operates at the conceptual level. Solution reveals structural understanding and transfer capacity._|
-
-
-
-## 2) Teaching Injection
-
-Determine which which units need teaching and consider how you might group them into lessons. Then create a json file injection for each one. Avoid making heaps of them unnecessarily, group by relevance.
-
-**Format:** Flat JSON object.
-```json
 {
-  "question": "Derive the electric field of a uniformly charged infinite plane using Gauss's Law.",
-  "studentAnswer": "Used cylindrical pillbox. Flux = 2EA = Q/ε₀ → E = σ/(2ε₀). Correct symmetry identification.",
-  "relevantUnits": [3, 7]
+  "questions": [
+    { "id": 1, "question": "..." },
+    { "id": 2, "question": "..." },
+    ...
+  ]
 }
-```
-**Field Constraints**
 
-| Key             | Type     | Notes                                                                                       |
-| --------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `question`      | `string` | Original prompt or exercise                                                                 |
-| `studentAnswer` | `string` | Raw response, not adjusted                                                                  |
-| `relevantUnits` | `int[]`  | Array of `unitId`s. Links/context auto-resolved from domain JSON during markdown generation |
-
+The array must contain exactly 10 questions ordered from easiest to hardest.

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const { compilePrompt } = require('./promptCompiler');
+const { generate } = require('./aiClient');
 const app = express();
 const PORT = 6969;
 
@@ -234,18 +235,14 @@ app.get('/api/xp', (req, res) => {
   res.json(xpState);
 });
 
-// POST XP injection - writes to progress file and history
-app.post('/api/xp', (req, res) => {
-  const { injections, domain } = req.body;
-  const injArray = Array.isArray(injections) ? injections : req.body;
-  if (!Array.isArray(injArray)) return res.status(400).json({ error: 'Invalid payload' });
-  if (!domain) return res.status(400).json({ error: 'domain required' });
+// ─── XP INJECTION HELPER ─────────────────────────────────────────────────────────
 
+function processXPInjections(domain, injArray) {
   const pPath = progressPath(domain);
-  if (!fs.existsSync(pPath)) return res.status(404).json({ error: 'Progress file not found' });
+  if (!fs.existsSync(pPath)) throw Object.assign(new Error('Progress file not found'), { status: 404 });
 
   backupProgress(domain);
-  let progressData = readJSON(pPath);
+  const progressData = readJSON(pPath);
   const sessionId = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
   const results = [];
 
@@ -254,35 +251,27 @@ app.post('/api/xp', (req, res) => {
     if (inj.difficultyScore < 20 || inj.difficultyScore > 100) continue;
     if (inj.performanceRatio < 0 || inj.performanceRatio > 1.0) continue;
 
-    // Calculate current XP for this unit from existing logs
     const unit = findUnitInProgress(progressData, inj.unitId);
     if (!unit) continue;
 
-    // Calculate cumulative XP and current band from existing logs
     let cumulativeXP = 0;
-    let currentBand = 'I';
     for (const log of (unit.logs || [])) {
       if (log.xpGain !== undefined) cumulativeXP += log.xpGain;
     }
-    currentBand = getBandInfo(cumulativeXP).lv;
+    const currentBand = getBandInfo(cumulativeXP).lv;
 
-    // Calculate new XP
     const dv = Math.min(100, inj.difficultyScore * inj.performanceRatio);
     const bandInfo = BANDS.find(b => b.lv === currentBand);
     const perfRatio = dv / bandInfo.expDV;
     const bm = Math.min(2.0, Math.max(-0.5, 2 * perfRatio - 0.8));
-
     const foundationMult = inj.isFoundation ? 0.3 : 1.0;
     const xpGain = Math.max(0, Math.round(bandInfo.base * bm * foundationMult));
 
     const oldCum = cumulativeXP;
     const oldBand = currentBand;
     cumulativeXP += xpGain;
-
     const newBandInfo = getBandInfo(cumulativeXP);
-    const bandShifted = oldBand !== newBandInfo.lv;
 
-    // Write log entry to progress file
     unit.logs.push({
       timestamp: new Date().toISOString(),
       dv: Math.round(dv * 100) / 100,
@@ -301,28 +290,33 @@ app.post('/api/xp', (req, res) => {
       dv: Math.round(dv * 100) / 100,
       bm: Math.round(bm * 100) / 100,
       delta: xpGain,
-      bandShifted,
+      bandShifted: oldBand !== newBandInfo.lv,
       sessionId
     });
   }
 
-  // Save to history file
   const hPath = historyPath(domain);
   const history = fs.existsSync(hPath) ? readJSON(hPath) : [];
-  history.push({
-    sessionId,
-    timestamp: new Date().toISOString(),
-    injections: injArray,
-    results
-  });
+  history.push({ sessionId, timestamp: new Date().toISOString(), injections: injArray, results });
+  writeJSON(pPath, progressData);
+  writeJSON(hPath, history);
+
+  return { success: true, sessionId, results };
+}
+
+// POST XP injection - writes to progress file and history
+app.post('/api/xp', (req, res) => {
+  const { injections, domain } = req.body;
+  const injArray = Array.isArray(injections) ? injections : req.body;
+  if (!Array.isArray(injArray)) return res.status(400).json({ error: 'Invalid payload' });
+  if (!domain) return res.status(400).json({ error: 'domain required' });
 
   try {
-    writeJSON(pPath, progressData);
-    writeJSON(hPath, history);
-    res.json({ success: true, results });
+    const xpResult = processXPInjections(domain, injArray);
+    res.json(xpResult);
   } catch (e) {
     console.error('XP save error:', e);
-    res.status(500).json({ error: 'XP save failed', details: e.message });
+    res.status(e.status || 500).json({ error: e.message });
   }
 });
 
@@ -418,6 +412,49 @@ app.delete('/api/xp', (req, res) => {
   } catch (e) {
     console.error('Clear XP save error:', e);
     res.status(500).json({ error: 'Failed to clear XP' });
+  }
+});
+
+// ─── TEST ENDPOINTS ───────────────────────────────────────────────────────────────
+
+app.post('/api/test/generate', async (req, res) => {
+  const { domain, unitIds } = req.body;
+  if (!domain || !Array.isArray(unitIds) || unitIds.length === 0)
+    return res.status(400).json({ error: 'domain and unitIds[] required' });
+
+  try {
+    const template = fs.readFileSync(path.join(PROMPTS_DIR, 'test.md'), 'utf8');
+    const prompt = compilePrompt(template, { domain, unitIds });
+    const raw = await generate(prompt, { json: true });
+    const { questions } = JSON.parse(raw);
+    res.json({ questions });
+  } catch (err) {
+    console.error('test/generate error:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/test/mark', async (req, res) => {
+  const { domain, unitIds, questions, answers } = req.body;
+  if (!domain || !Array.isArray(unitIds) || !Array.isArray(questions) || !Array.isArray(answers))
+    return res.status(400).json({ error: 'domain, unitIds, questions[], answers[] required' });
+
+  try {
+    const template = fs.readFileSync(path.join(PROMPTS_DIR, 'test-mark.md'), 'utf8');
+    const base = compilePrompt(template, { domain, unitIds });
+    const answerMap = Object.fromEntries(answers.map(a => [a.id, a.answer]));
+    const qa = questions.map(q =>
+      `Q${q.id}: ${q.question}\nA${q.id}: ${answerMap[q.id] ?? '(no answer)'}`
+    ).join('\n\n');
+    const prompt = `${base}\n\n---\n\n${qa}`;
+
+    const raw = await generate(prompt, { json: true });
+    const { results, xpInjections } = JSON.parse(raw);
+    const xpResult = processXPInjections(domain, xpInjections);
+    res.json({ results, xpResult });
+  } catch (err) {
+    console.error('test/mark error:', err);
+    res.status(500).json({ error: err.message });
   }
 });
 


### PR DESCRIPTION
Add LLM-driven test generation and marking endpoints and refactor XP processing. Imported generate from aiClient and updated aiAdapters (gemini/groq) to request JSON responses when options.json is set. Introduced /api/test/generate and /api/test/mark endpoints and a new prompts/test-mark.md prompt; prompts/test.md was simplified to require a 10-question JSON array. Extracted XP injection logic into processXPInjections for clearer flow, improved error handling/status propagation, ensured progress/history are written, and adjusted band/delta calculations and logging. Minor docs update in AI_API_CONTRACT.md (recipient change, removed `Incomplete` state, and instruct to implement an XPModal React component).