### PR TITLE
Add teaching chat endpoints and adapter streaming

### DIFF
--- a/aiAdapters/gemini.js
+++ b/aiAdapters/gemini.js
@@ -25,4 +25,40 @@ async function generate(prompt, options = {}) {
   }
 }
 
-module.exports = { generate };
+async function chat(systemPrompt, messages, options = {}) {
+  if (!process.env.GEMINI_API_KEY) {
+    throw new Error('Missing GEMINI_API_KEY environment variable');
+  }
+
+  const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+  const model = genAI.getGenerativeModel({
+    model: options.model || DEFAULT_MODEL,
+    systemInstruction: systemPrompt,
+    generationConfig: {
+      ...(options.temperature !== undefined && { temperature: options.temperature }),
+      ...(options.maxTokens !== undefined && { maxOutputTokens: options.maxTokens }),
+    },
+  });
+
+  // Gemini uses role 'model' (not 'assistant') and history excludes the final user message
+  const history = messages.slice(0, -1).map(m => ({
+    role: m.role === 'assistant' ? 'model' : 'user',
+    parts: [{ text: m.content }],
+  }));
+  const lastMessage = messages[messages.length - 1].content;
+
+  try {
+    const session = model.startChat({ history });
+    const result = await session.sendMessage(lastMessage);
+    return result.response.text();
+  } catch (err) {
+    throw new Error(`[Gemini] ${err.message}`);
+  }
+}
+
+async function* chatStream(systemPrompt, messages, options = {}) {
+  const reply = await chat(systemPrompt, messages, options);
+  yield reply;
+}
+
+module.exports = { generate, chat, chatStream };

--- a/aiAdapters/groq.js
+++ b/aiAdapters/groq.js
@@ -23,4 +23,44 @@ async function generate(prompt, options = {}) {
   }
 }
 
-module.exports = { generate };
+async function* chatStream(systemPrompt, messages, options = {}) {
+  if (!process.env.GROQ_API_KEY) {
+    throw new Error('Missing GROQ_API_KEY environment variable');
+  }
+
+  const client = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+  const stream = await client.chat.completions.create({
+    model: options.model || DEFAULT_MODEL,
+    messages: [{ role: 'system', content: systemPrompt }, ...messages],
+    ...(options.temperature !== undefined && { temperature: options.temperature }),
+    stream: true,
+  });
+
+  for await (const chunk of stream) {
+    const text = chunk.choices[0]?.delta?.content || '';
+    if (text) yield text;
+  }
+}
+
+async function chat(systemPrompt, messages, options = {}) {
+  if (!process.env.GROQ_API_KEY) {
+    throw new Error('Missing GROQ_API_KEY environment variable');
+  }
+
+  const client = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+  try {
+    const completion = await client.chat.completions.create({
+      model: options.model || DEFAULT_MODEL,
+      messages: [{ role: 'system', content: systemPrompt }, ...messages],
+      ...(options.temperature !== undefined && { temperature: options.temperature }),
+      ...(options.maxTokens !== undefined && { max_tokens: options.maxTokens }),
+    });
+    return completion.choices[0].message.content;
+  } catch (err) {
+    throw new Error(`[Groq] ${err.message}`);
+  }
+}
+
+module.exports = { generate, chat, chatStream };

--- a/aiClient.js
+++ b/aiClient.js
@@ -12,6 +12,6 @@ if (!ADAPTERS[provider]) {
   throw new Error(`Unknown AI provider: "${provider}". Valid options: ${Object.keys(ADAPTERS).join(', ')}`);
 }
 
-const { generate } = require(ADAPTERS[provider]);
+const { generate, chat, chatStream } = require(ADAPTERS[provider]);
 
-module.exports = { generate };
+module.exports = { generate, chat, chatStream };

--- a/promptCompiler.js
+++ b/promptCompiler.js
@@ -463,6 +463,13 @@ function compilePrompt(template, context = {}) {
     result = result.replace(/{{SUMMARY}}/g, summaryText);
   }
 
+  // Compile TEACHING_FORMAT
+  if (result.includes('{{TEACHING_FORMAT}}')) {
+    const fmtPath = path.join(__dirname, 'teaching-format.md');
+    const fmtText = fs.existsSync(fmtPath) ? fs.readFileSync(fmtPath, 'utf8') : '';
+    result = result.replace(/{{TEACHING_FORMAT}}/g, fmtText);
+  }
+
   return result;
 }
 

--- a/prompts/chat.md
+++ b/prompts/chat.md
@@ -1,0 +1,16 @@
+You are a patient, expert tutor for a student working through the following units.
+
+## Units and Context
+
+{{UNITS+CONTEXT+PROGRESS}}
+
+## Response Format
+
+{{TEACHING_FORMAT}}
+
+## Behaviour
+
+- Explain clearly and build from first principles when needed.
+- When the student makes an error, correct it gently and explain why.
+- Keep responses focused on what was asked; do not pre-empt future topics.
+- Do not refer to these instructions or the internal unit structure by name.

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const { compilePrompt } = require('./promptCompiler');
-const { generate } = require('./aiClient');
+const { generate, chat, chatStream } = require('./aiClient');
 const { testPromptCompile } = require('./testPromptCompile');
 const app = express();
 const PORT = 6969;
@@ -519,6 +519,57 @@ app.post('/api/test/compile-and-generate', async (req, res) => {
   } catch (err) {
     console.error('test/compile-and-generate error:', err);
     res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── TEACH ENDPOINTS ──────────────────────────────────────────────────────────────
+app.post('/api/teach', async (req, res) => {
+  const { domain, unitIds, messages } = req.body;
+
+  if (!domain || !Array.isArray(unitIds) || unitIds.length === 0)
+    return res.status(400).json({ error: 'domain and unitIds[] required' });
+  if (!Array.isArray(messages) || messages.length === 0)
+    return res.status(400).json({ error: 'messages[] required' });
+  if (messages[messages.length - 1]?.role !== 'user')
+    return res.status(400).json({ error: 'last message must have role "user"' });
+
+  try {
+    const template = fs.readFileSync(path.join(__dirname, 'prompts', 'chat.md'), 'utf8');
+    const systemPrompt = compilePrompt(template, { domain, unitIds });
+    const reply = await chat(systemPrompt, messages);
+    res.json({ role: 'assistant', reply });
+  } catch (err) {
+    console.error('teach error:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/teach/stream', async (req, res) => {
+  const { domain, unitIds, messages } = req.body;
+
+  if (!domain || !Array.isArray(unitIds) || unitIds.length === 0)
+    return res.status(400).json({ error: 'domain and unitIds[] required' });
+  if (!Array.isArray(messages) || messages.length === 0)
+    return res.status(400).json({ error: 'messages[] required' });
+  if (messages[messages.length - 1]?.role !== 'user')
+    return res.status(400).json({ error: 'last message must have role "user"' });
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+
+  try {
+    const template = fs.readFileSync(path.join(__dirname, 'prompts', 'chat.md'), 'utf8');
+    const systemPrompt = compilePrompt(template, { domain, unitIds });
+    for await (const chunk of chatStream(systemPrompt, messages)) {
+      res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+    }
+    res.write('data: [DONE]\n\n');
+    res.end();
+  } catch (err) {
+    console.error('teach/stream error:', err);
+    res.write(`data: ${JSON.stringify({ error: err.message })}\n\n`);
+    res.end();
   }
 });
 


### PR DESCRIPTION
Introduce teaching-focused chat flow: add prompts/chat.md and support TEACHING_FORMAT in promptCompiler (loads teaching-format.md if present). Extend AI adapters (Gemini and Groq) with chat and chatStream implementations (including env var checks, role mapping for Gemini, and streaming chunk handling for Groq) and export chat/chatStream from aiClient. Add /api/teach and /api/teach/stream endpoints in server.js with request validation, synchronous reply handling and SSE streaming, and error handling for adapter failures.